### PR TITLE
OT/Galdera: Cyrus route doesn't have Ophiria in Therion 4

### DIFF
--- a/src/pages/Octopath-Traveler/Full-Game/Galdera-Aebers-Updated.mdx
+++ b/src/pages/Octopath-Traveler/Full-Game/Galdera-Aebers-Updated.mdx
@@ -1113,11 +1113,14 @@ TP **Northreach**.
 
 ### Therion Ch.4 Start
 Purchase **Fortifying L** and Steal **Platinum Sword**. 
-Talk to tavern keeper, swap Olberic for H'aanit.
+Talk to tavern keeper.
 
 <Menu>
 
-##### Equipment
+##### Party
+ * swap Olberic for H'aanit
+
+##### Equipment (in the tavern keeper's menu)
  * Therion: Battle-tested Blade, -Empowering Bracelet, +Captain’s Badge
  * Haanit: Optimize, Empowering Bracelet x2
  * Ophilia: Unerring Bracelet


### PR DESCRIPTION
I'm not super sure about this one.

At this point, Cyrus has Stimulating Bracelet and Elemental Augmentator. If we were to equip an Unerring Bracelet on him, then we would have to choose one of these to unequip. In practice I haven't found that I needed an accuracy boost, but I may have just been lucky.

If just skipping the Ophilia equip is not the right fix, please advise and I'll update.