### PR TITLE
OT/Galdera: equip Primeval Bow of Storms before Simeon

### DIFF
--- a/src/pages/Octopath-Traveler/Full-Game/Galdera-Aebers-Updated.mdx
+++ b/src/pages/Octopath-Traveler/Full-Game/Galdera-Aebers-Updated.mdx
@@ -1244,6 +1244,13 @@ If you don't have enough, buy it later in Duskbarrow.
 
 Sidequest: Again with Alaic (talk to the bandit, Tonitrus Canere x3)
 
+<Menu>
+
+##### Equipment
+ * Cyrus: Primeval Bow of Storms
+
+</Menu>
+
 TP **Noblecourt**.
 
 ### Primrose Ch.3


### PR DESCRIPTION
I added the equip at the beginning of the Simeon menu. This sounds the most sensible.

Alternatively, we could equip it before Albus, since we are going to do Ventus there anyway. But that would mean one extra menu, and I don't think that we need the Bow of Storms to win Albus.