### PR TITLE
OT/Galdera: don't boost Elemental Break in Simeon 2

### DIFF
--- a/src/pages/Octopath-Traveler/Full-Game/Galdera-Aebers-Updated.mdx
+++ b/src/pages/Octopath-Traveler/Full-Game/Galdera-Aebers-Updated.mdx
@@ -1303,7 +1303,7 @@ Buy **Sharp L, Crit L**.
 
 #### Simeon, The Puppet Master (64/92 SP)
 ##### Turn 1
- * Cyrus: Elemental Break x2
+ * Cyrus: Elemental Break
  * Tressa: Defend
  * Therion: Defend
  * Primrose: Attack x2


### PR DESCRIPTION
If you need to kill T3, you have Peacock Strut instead.